### PR TITLE
Remove redis-cli that is added upstream

### DIFF
--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -36,8 +36,3 @@ RUN cd /root/installer; ./enable.sh \
   redis \
   soap \
   sockets
-
- # Tool: redis-cli
-# ---------------
-# we copy instead of using redis-cli or redis-tools due to inconsistent versions
-COPY --from=redis:5.0 /usr/local/bin/redis-cli /usr/local/bin/redis-cli


### PR DESCRIPTION
Also fixes the bug that redis:5.0 picks buster on stretch, which doesn't work due to libc version