### PR TITLE
Add build packages if not amd64

### DIFF
--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -14,6 +14,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
   # package dependencies \
     graphviz \
     procps \
+    $([ "$(uname -m)" = x86_64 ] || echo build-essential python) \ 
   # clean \
  && apt-get auto-remove -qq -y \
  && apt-get clean \


### PR DESCRIPTION
Other architectures (in this case arm64) don't have many pre-compiled npm package versions, so have to be compiled.

Python2 (via python-is-python2 redirect on bullseye) is needed as well, as node-gyp requires it for the compilation